### PR TITLE
Fix escaping issues

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -117,7 +117,7 @@
               "${elemAt comp 2}.${elemAt comp 4}";
           in {
             label = "Build ${displayName}";
-            command = "${nixBinPath}nix-build -A ${concatStringsSep "." comp}";
+            command = "${nixBinPath}nix-build --no-out-link -A ${lib.escapeShellArg ''"${concatStringsSep ''"."'' comp}"''}";
             inherit agents;
           } // optionalAttrs hasArtifacts {
             artifact_paths = map (art: "result${art}") drv.meta.artifacts;
@@ -129,19 +129,19 @@
 
         check = name: {
           label = elemAt name 2;
-          command = "${nixBinPath}nix-build --no-out-link -A ${concatStringsSep "." name}";
+            command = "${nixBinPath}nix-build --no-out-link -A ${lib.escapeShellArg ''"${concatStringsSep ''"."'' name}"''}";
           inherit agents;
         };
 
         checkSteps = map check checkNames;
 
-        doDeploy = { branch, profile, user ? "deploy", ... }: {
+        doDeploy = { branch, node ? branch, profile, user ? "deploy", ... }: {
           label = "Deploy ${branch} ${profile}";
           branches = [ branch ];
           command =
             "${
               inputs.deploy.defaultApp.${head systems}.program
-            } .#${branch}.${profile} --ssh-user ${user} --fast-connection true";
+            } ${lib.escapeShellArg ''.#"${node}"."${profile}"''} --ssh-user ${lib.escapeShellArg user} --fast-connection true";
           inherit agents;
         };
 


### PR DESCRIPTION
We need to account for the fact that the attribute names are first
interpreted by the shell and then interpreted by Nix itself when
building. The latter means we have to enclose every attribute in path
in double quotes (""), the former means we need to quote the entire
argument in single quotes to prevent interpretation by shell. We
_hope_ that the attribute paths don't contain double quotation marks,
since AFAIU there's no way to make nix evaluate or build attributes
which do have them.
